### PR TITLE
PreSelected color bug fix

### DIFF
--- a/THSegmentedControl/THSegmentedControl.m
+++ b/THSegmentedControl/THSegmentedControl.m
@@ -513,7 +513,6 @@ float const THSegmentedControlAnimationDuration = 0.1f;
 
 - (void)setSegmentBackgroundColor:(UIColor *)segmentBackgroundColor
 {
-    NSLog(@"%@", segmentBackgroundColor);
     if (_segmentBackgroundColor != segmentBackgroundColor) {
         _segmentBackgroundColor = segmentBackgroundColor;
         if (self.selected) self.textField.textColor = segmentBackgroundColor;


### PR DESCRIPTION
This PR addresses a bug causing the preSelected color to be retained when the segment is unselected. Also removed an unneeded NSLog.
#### Steps to reproduce:
1. Touch down inside of a segment
2. Drag to another segment without leaving the THSegmentedControl frame
3. Touch up
#### Result:

The originally touched segment turns the preSelected color and not return to the initial segmentBackgroundColor
#### Fix:

Reset background color when `changeSelectorToPreSelectionColor` is called and the current segment is not preSelected
